### PR TITLE
Spectral line support

### DIFF
--- a/awesimsoss/awesim.py
+++ b/awesimsoss/awesim.py
@@ -574,7 +574,7 @@ class TSO(object):
             self._planet = spectrum
 
     @run_required
-    def _select_data(self, order, noise, reshape=3):
+    def _select_data(self, order, noise, reshape=True):
         """
         Select the data given the order and noise args
 
@@ -607,8 +607,7 @@ class TSO(object):
         return tso
 
     @run_required
-    def plot(self, idx=0, scale='linear', order=None, noise=True,
-                   traces=False, saturation=0.8, draw=True):
+    def plot(self, idx=0, scale='linear', order=None, noise=True, traces=False, saturation=0.8, draw=True):
         """
         Plot a TSO frame
 

--- a/awesimsoss/awesim.py
+++ b/awesimsoss/awesim.py
@@ -209,6 +209,9 @@ class TSO(object):
         # Add the line to the line list
         self.lines.add_row([name, profile, x_0, amplitude, fwhm, line])
 
+        # Reset the psfs
+        self._reset_psfs()
+
     @run_required
     def add_noise(self, zodi_scale=1., offset=500):
         """
@@ -950,12 +953,11 @@ class TSO(object):
 
         # Simulate star with transiting exoplanet by including transmission spectrum and orbital params
         import batman
-        import astropy.constants as ac
-        planet1D = np.genfromtxt(resource_filename('awesimsoss', '/files/WASP107b_pandexo_input_spectrum.dat'), unpack=True)
+        from hotsoss import PLANET_DATA
         params = batman.TransitParams()
         params.t0 = 0.                                # time of inferior conjunction
         params.per = 5.7214742                        # orbital period (days)
-        params.a = 0.0558*q.AU.to(ac.R_sun)*0.66      # semi-major axis (in units of stellar radii)
+        params.a = 3.5                                # semi-major axis (in units of stellar radii)
         params.inc = 89.8                             # orbital inclination (in degrees)
         params.ecc = 0.                               # eccentricity
         params.w = 90.                                # longitude of periastron (in degrees)
@@ -965,7 +967,7 @@ class TSO(object):
         tmodel.teff = 3500                            # effective temperature of the host star
         tmodel.logg = 5                               # log surface gravity of the host star
         tmodel.feh = 0                                # metallicity of the host star
-        tso.simulate(planet=planet1D, tmodel=tmodel)
+        tso.simulate(planet=PLANET_DATA, tmodel=tmodel)
         """
         # Check that there is star data
         if self.star is None:

--- a/awesimsoss/awesim.py
+++ b/awesimsoss/awesim.py
@@ -574,6 +574,33 @@ class TSO(object):
             self._planet = spectrum
 
     @run_required
+    def _select_data(self, order, noise):
+        """
+        Select the data given the order and noise args
+
+        Parameters
+        ----------
+        order: int (optional)
+            The order to use, [1, 2, 3]
+        noise: bool
+            Include noise model
+
+        Returns
+        -------
+        np.ndarray
+            The selected data
+        """
+        if order in [1, 2]:
+            tso = getattr(self, 'tso_order{}_ideal'.format(order))
+        else:
+            if noise:
+                tso = self.tso
+            else:
+                tso = self.tso_ideal
+
+        return tso
+
+    @run_required
     def plot(self, idx=0, scale='linear', order=None, noise=True,
                    traces=False, saturation=0.8, draw=True):
         """
@@ -585,7 +612,7 @@ class TSO(object):
             The frame index to plot
         scale: str
             Plot scale, ['linear', 'log']
-        order: sequence
+        order: int (optional)
             The order to isolate
         noise: bool
             Plot with the noise model
@@ -597,13 +624,7 @@ class TSO(object):
             Render the figure instead of returning it
         """
         # Get the data cube
-        if order in [1, 2]:
-            tso = getattr(self, 'tso_order{}_ideal'.format(order))
-        else:
-            if noise:
-                tso = self.tso
-            else:
-                tso = self.tso_ideal
+        tso = self._select_datar(order, noise)
 
         # Reshape data
         tso.shape = self.dims3
@@ -636,13 +657,7 @@ class TSO(object):
             Render the figure instead of returning it
         """
         # Get the data cube
-        if order in [1, 2]:
-            tso = getattr(self, 'tso_order{}_ideal'.format(order))
-        else:
-            if noise:
-                tso = self.tso
-            else:
-                tso = self.tso_ideal
+        tso = self._select_data(order, noise)
 
         # Reshape data
         tso.shape = self.dims3
@@ -753,13 +768,8 @@ class TSO(object):
         draw: bool
             Render the figure instead of returning it
         """
-        if order in [1, 2]:
-            tso = getattr(self, 'tso_order{}_ideal'.format(order))
-        else:
-            if noise:
-                tso = self.tso
-            else:
-                tso = self.tso_ideal
+        # Get the data cube
+        tso = self._select_data(order, noise)
 
         # Get extracted spectrum (Column sum for now)
         wave = np.mean(self.wave[0], axis=0)

--- a/awesimsoss/awesim.py
+++ b/awesimsoss/awesim.py
@@ -574,7 +574,7 @@ class TSO(object):
             self._planet = spectrum
 
     @run_required
-    def _select_data(self, order, noise):
+    def _select_data(self, order, noise, reshape=3):
         """
         Select the data given the order and noise args
 
@@ -584,6 +584,8 @@ class TSO(object):
             The order to use, [1, 2, 3]
         noise: bool
             Include noise model
+        reshape: bool
+            Reshape to 3 dimensions
 
         Returns
         -------
@@ -597,6 +599,10 @@ class TSO(object):
                 tso = self.tso
             else:
                 tso = self.tso_ideal
+
+        # Reshape data
+        if reshape:
+            tso.shape = self.dims3
 
         return tso
 
@@ -624,10 +630,7 @@ class TSO(object):
             Render the figure instead of returning it
         """
         # Get the data cube
-        tso = self._select_datar(order, noise)
-
-        # Reshape data
-        tso.shape = self.dims3
+        tso = self._select_data(order, noise)
 
         # Set the plot args
         wavecal = self.wave
@@ -658,9 +661,6 @@ class TSO(object):
         """
         # Get the data cube
         tso = self._select_data(order, noise)
-
-        # Reshape data
-        tso.shape = self.dims3
 
         # Make the figure
         fig = plotting.plot_ramp(tso)
@@ -773,7 +773,7 @@ class TSO(object):
 
         # Get extracted spectrum (Column sum for now)
         wave = np.mean(self.wave[0], axis=0)
-        flux_out = np.sum(tso.reshape(self.dims3)[frame].data, axis=0)
+        flux_out = np.sum(tso[frame].data, axis=0)
         response = 1./self.order1_response
 
         # Convert response in [mJy/ADU/s] to [Flam/ADU/s] then invert so

--- a/tests/test_awesim.py
+++ b/tests/test_awesim.py
@@ -51,6 +51,37 @@ class test_TSO(unittest.TestCase):
         self.star = STAR_DATA
         self.planet = PLANET_DATA
 
+    def test_add_lines(self):
+        """Test the add_lines method"""
+        # Make the TSO object
+        tso = TSO(ngrps=2, nints=2, star=self.star)
+        amp = 1e-14*q.erg/q.s/q.cm**2/q.AA
+        x_0 = 1.*q.um
+        fwhm = 0.01*q.um
+
+        # Add a bad profile name
+        kwargs = {'amplitude': 1e-14*q.erg/q.s/q.cm**2/q.AA, 'x_0': 1.*q.um, 'fwhm': 0.01*q.um, 'profile': 'foo'}
+        self.assertRaises(ValueError, tso.add_line, **kwargs)
+
+        # Add a Lorentzian line
+        kwargs = {'amplitude': amp, 'x_0': x_0, 'fwhm': fwhm, 'profile': 'lorentz'}
+        tso.add_line(**kwargs)
+
+        # Add a Gaussian line
+        kwargs = {'amplitude': amp, 'x_0': x_0, 'fwhm': fwhm, 'profile': 'gaussian'}
+        tso.add_line(**kwargs)
+
+        # Add a Voigt line
+        kwargs = {'amplitude': amp, 'x_0': x_0, 'fwhm': (fwhm, fwhm), 'profile': 'voigt'}
+        tso.add_line(**kwargs)
+
+        # Add a bad Voigt fwhm
+        kwargs = {'amplitude': amp, 'x_0': x_0, 'fwhm': fwhm, 'profile': 'voigt'}
+        self.assertRaises(TypeError, tso.add_line, **kwargs)
+
+        # Check that the 3 good lines have been added
+        self.assertEqual(len(tso.lines), 3)
+
     def test_export(self):
         """Test the export method"""
         # Make the TSO object and save
@@ -210,7 +241,7 @@ class test_TSO(unittest.TestCase):
         # Make the TSO object
         tso = TSO(ngrps=2, nints=2, star=self.star)
 
-        # Bad fiilter
+        # Bad filter
         self.assertRaises(ValueError, setattr, tso, 'filter', 'foo')
 
         # Bad ncols


### PR DESCRIPTION
This PR adds the `add_line` method to the `TSO` class, which allows the user to add a Gaussian, Lorentz, or Voigt profile spectral line to the stellar spectrum. This is used primarily for testing but can also prove handy in modeling a source with some specific absorption or emission features.