### PR TITLE
Sweet spot

### DIFF
--- a/awesimsoss/__init__.py
+++ b/awesimsoss/__init__.py
@@ -4,6 +4,6 @@
 
 __author__ = """Joe Filippazzo"""
 __email__ = 'jfilippazzo@stsci.edu'
-__version__ = '0.2.0'
+__version__ = '0.3.4'
 
 from .awesim import TSO, TestTSO, BlackbodyTSO, ModelTSO

--- a/awesimsoss/awesim.py
+++ b/awesimsoss/awesim.py
@@ -81,7 +81,7 @@ class TSO(object):
     Generate NIRISS SOSS time series observations
     """
     def __init__(self, ngrps, nints, star=None, planet=None, tmodel=None, snr=700,
-                 filter='CLEAR', subarray='SUBSTRIP256', orders=[1, 2], nresets=0,
+                 filter='CLEAR', subarray='SUBSTRIP256', orders=[1, 2], nresets=1,
                  obs_date=None, target='New Target', title=None, verbose=True):
         """
         Initialize the TSO object and do all pre-calculations
@@ -322,7 +322,9 @@ class TSO(object):
         mod.meta.instrument.name = 'NIRISS'
         mod.meta.instrument.detector = 'NIS'
         mod.meta.instrument.filter = self.filter
+        mod.meta.instrument.filter_position = self.filter_wheel
         mod.meta.instrument.pupil = 'GR700XD'
+        mod.meta.instrument.pupil_position = self.pupil_wheel
         mod.meta.exposure.type = 'NIS_SOSS'
         mod.meta.exposure.nints = self.nints
         mod.meta.exposure.ngroups = self.ngrps
@@ -332,8 +334,8 @@ class TSO(object):
         mod.meta.exposure.frame_time = self.frame_time
         mod.meta.exposure.group_time = self.group_time
         mod.meta.exposure.duration = self.duration.to(q.s).value 
-        mod.meta.exposure.nresets_at_start = 1
-        mod.meta.exposure.nresets_between_ints = 1
+        mod.meta.exposure.nresets_at_start = self.nresets
+        mod.meta.exposure.nresets_between_ints = self.nresets
         mod.meta.subarray.name = self.subarray
         mod.meta.subarray.xsize = data.shape[3]
         mod.meta.subarray.ysize = data.shape[2]

--- a/awesimsoss/awesim.py
+++ b/awesimsoss/awesim.py
@@ -547,8 +547,7 @@ class TSO(object):
 
     @nrows.setter
     def nrows(self, err):
-        """Error when trying to change the number of rows
-        """
+        """Error when trying to change the number of rows"""
         raise TypeError("The number of rows is fixed by setting the 'subarray' attribute.")
 
     @property

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.3
+current_version = 0.3.4
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/hover2pi/awesimsoss',
-    version='0.3.3',
+    version='0.3.4',
     zip_safe=False,
 )


### PR DESCRIPTION
This PR implements telescope pointing (i.e. the "sweet spot") and wheel position changes to the simulations. These changes will update the trace tilt, PSF distortions, and trace positions accordingly. By making the pointing a variable, this also allows for simulation of nearby point source contamination, i.e. simulating more than one star on the detector with different Order 0 positions.