### PR TITLE
LDCs model grid can be user-defined

### DIFF
--- a/awesimsoss/awesim.py
+++ b/awesimsoss/awesim.py
@@ -1131,7 +1131,7 @@ class TSO(object):
             self._tmodel = model
 
             # Update ld_coeffs
-            self.ld_coeffs = [mt.generate_SOSS_ldcs(self.avg_wave[order - 1], model.limb_dark, params) for order in self.orders]
+            self.ld_coeffs = [mt.generate_SOSS_ldcs(self.avg_wave[order - 1], model.limb_dark, params, model_grid = self.model_grid) for order in self.orders]
 
     @property
     def tso_ideal(self):


### PR DESCRIPTION
Hey @hover2pi,

 Turns out that currently even if you change the `model_grid` string when creating any of the `TSO` objects, the only grid that is used is `ACES`. This is because that string is not being passed to the SOSS LDCs calculator --- this one-liner fixes that.

 Let me know if you have any questions!

N.