### PR TITLE
Fixed bug on frame time (was set to half the frame-time).

### DIFF
--- a/awesimsoss/awesim.py
+++ b/awesimsoss/awesim.py
@@ -720,7 +720,7 @@ class TSO(object):
             grp_idx = np.concatenate([np.arange(self.nresets, self.nresets + self.ngrps) + n * (self.nresets + self.ngrps) for n in range(self.nints)])
 
             # The time increments
-            dt = TimeDelta(self.frame_time / 2., format='sec')
+            dt = TimeDelta(self.frame_time, format='sec')
 
             # Integration time of each frame in seconds
             self.inttime = np.tile((dt * grp_idx).sec[:self.ngrps], self.nints)


### PR DESCRIPTION
Hi @hover2pi,

In the latest version of `awesimsoss`, the spacing between groups/frames is set to half a frame-time. Perhaps what was intended here was to pose the time-tags at half the group-time instead of at the end? If that's the case, that has to be made through a substraction of half a frame-time to self.time I believe!

Leaving here for posterity, as I know you are working on a PR to incorporate the latest reference files in CRDS.

Cheers,
Néstor